### PR TITLE
Added utility include to range.

### DIFF
--- a/src/range.cpp
+++ b/src/range.cpp
@@ -1,6 +1,7 @@
 #include "cxxplot/range.hpp"
 
 #include <algorithm>
+#include <utility>
 
 namespace cxxplot
 {


### PR DESCRIPTION
In order to compile with `gcc 12.2.1` on Linux, I had to explicitly add the `<utility>` include in `range.cpp` for the definition of `std::exchange`. 