### PR TITLE
include cstdint

### DIFF
--- a/include/cxxplot/utils.hpp
+++ b/include/cxxplot/utils.hpp
@@ -39,6 +39,7 @@
 // Additional information can be found in the provided "licenses" folder.
 
 #pragma once
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Needed to compile using GCC-13.